### PR TITLE
Fix indent syntax error

### DIFF
--- a/Switchboard.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Switchboard.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -569,7 +569,7 @@ class Plugin(indigo.PluginBase):
 				#
 				# email substitute
 				#
-                email_text = self.substitute(devicerec.globalProps[plugin_id]["CustomEmailText"])
+				email_text = self.substitute(devicerec.globalProps[plugin_id]["CustomEmailText"])
 				indigo.server.sendEmailTo ( ";".join(email_addrs), "Switchboard Alert - %s..." % ZoneName , email_text )
 			else:
 				# Send the standard Email Template


### PR DESCRIPTION
Line 572 used spaces to indent but parent lines used tabs.